### PR TITLE
feat: hideTextField in ColorPicker component

### DIFF
--- a/src/components/ColorPicker.jsx
+++ b/src/components/ColorPicker.jsx
@@ -55,6 +55,7 @@ const ColorPicker = ({
   onOpen,
   doPopup,
   disableAlpha,
+  hideTextfield,
 }) => {
   const refPicker = React.useRef(null);
   const [open, setOpen] = React.useState(openAtStart);
@@ -117,6 +118,17 @@ const ColorPicker = ({
     );
   }
 
+  let textField = null;
+  if (!hideTextfield) {
+    textField = disableTextfield ? (
+      <div role="button" data-testid="colorpicker-noinput" onClick={handleClick}>
+        {color.raw}
+      </div>
+    ) : (
+      <TextField color="primary" value={raw} onChange={handleChange} data-testid="colorpicker-input" />
+    );
+  }
+
   return (
     <StyledRoot ref={refPicker}>
       <ColorButton
@@ -125,13 +137,7 @@ const ColorPicker = ({
         color={color}
         onClick={handleClick}
       />
-      {disableTextfield ? (
-        <div role="button" data-testid="colorpicker-noinput" onClick={handleClick}>
-          {color.raw}
-        </div>
-      ) : (
-        <TextField color="primary" value={raw} onChange={handleChange} data-testid="colorpicker-input" />
-      )}
+      {textField}
       {box}
     </StyledRoot>
   );
@@ -151,6 +157,7 @@ ColorPicker.propTypes = {
     Don't use alpha
    */
   disableAlpha: PropTypes.bool,
+  hideTextfield: PropTypes.bool,
 };
 
 ColorPicker.defaultProps = {
@@ -163,6 +170,7 @@ ColorPicker.defaultProps = {
   openAtStart: false,
   doPopup: undefined,
   disableAlpha: false,
+  hideTextfield: false,
 };
 
 export default uncontrolled(ColorPicker);

--- a/stories/ColorPicker.stories.js
+++ b/stories/ColorPicker.stories.js
@@ -127,3 +127,12 @@ export const Localization = () => {
 Localization.story = {
   parameters: { defaultValue: 'red', palette: paletteObj, deferred: true },
 };
+
+export const HideTextfield = () => (
+  <div style={style}>
+    <ColorPicker defaultValue="red" hideTextfield />
+  </div>
+);
+HideTextfield.story = {
+  parameters: { defaultValue: 'red', hideTextfield: true },
+};

--- a/test/ColorPicker.test.js
+++ b/test/ColorPicker.test.js
@@ -137,3 +137,8 @@ test('ColorPicker open', async () => {
   fireEvent.click(buttons[6]);
   expect(onChange).toHaveBeenCalledTimes(1);
 });
+
+test('ColorPicker hideTextfield', async () => {
+  const { queryAllByTestId } = render(<ColorPicker value="red" hideTextfield />);
+  expect(await queryAllByTestId('colorpicker-noinput')).toEqual([]);
+});

--- a/test/ColorPicker.test.js
+++ b/test/ColorPicker.test.js
@@ -140,5 +140,6 @@ test('ColorPicker open', async () => {
 
 test('ColorPicker hideTextfield', async () => {
   const { queryAllByTestId } = render(<ColorPicker value="red" hideTextfield />);
+  expect(await queryAllByTestId('colorpicker-input')).toEqual([]);
   expect(await queryAllByTestId('colorpicker-noinput')).toEqual([]);
 });


### PR DESCRIPTION
### Fix issues

- [x] #72 

### Description
This PR adds the `hideTextfield` prop to the ColorPicker component to avoid rendering the text field.

### Check List

- [x] respect code conventions and usages
- [x] tests and 100% coverage
- [x] well documented
- [x] self review

### Review targets:
- nodejs / npm / yarn