### PR TITLE
Add hideTextfield to typescript props

### DIFF
--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -29,6 +29,7 @@
   interface ColorPickerProps {
     value?: Color | string | number;
     disableTextfield?: boolean;
+    hideTextfield?: boolean;
     deferred?: boolean;
     palette?: null;
     inputFormats?: string[];


### PR DESCRIPTION
The newly added hideTextfield option was missing from the Typescript props.