### PR TITLE
fix arguments for ColorTool.validateColor call

### DIFF
--- a/src/components/ColorButton.jsx
+++ b/src/components/ColorButton.jsx
@@ -51,7 +51,7 @@ const Styleddiv = styled.div`
  */
 const ColorButton = ({ color: c, size, borderWidth, borderColor, forwardRef, tooltip, disableAlpha, ...props }) => {
   const { t, i18n } = useTranslate();
-  const color = ColorTool.validateColor(c, t, disableAlpha, i18n.language);
+  const color = ColorTool.validateColor(ci, disableAlpha, t, i18n.language);
   const translated = t(tooltip);
   const style = color.css; // || { backgroundColor: ColorTool.getCssColor(color) };
   let l = color.hsl[2] - 10;

--- a/src/components/ColorButton.jsx
+++ b/src/components/ColorButton.jsx
@@ -51,7 +51,7 @@ const Styleddiv = styled.div`
  */
 const ColorButton = ({ color: c, size, borderWidth, borderColor, forwardRef, tooltip, disableAlpha, ...props }) => {
   const { t, i18n } = useTranslate();
-  const color = ColorTool.validateColor(ci, disableAlpha, t, i18n.language);
+  const color = ColorTool.validateColor(c, disableAlpha, t, i18n.language);
   const translated = t(tooltip);
   const style = color.css; // || { backgroundColor: ColorTool.getCssColor(color) };
   let l = color.hsl[2] - 10;


### PR DESCRIPTION
### Fix issues

- [x] #86 

### Description

arguments were in the wrong order

### Check List

- [x] respect code conventions and usages
- [x] tests and 100% coverage
- [ ] well documented
- [ ] self review

### Review targets:
- nodejs / npm / yarn