### PR TITLE
fix: openAtStart wrong position

### DIFF
--- a/src/components/ColorPicker.jsx
+++ b/src/components/ColorPicker.jsx
@@ -9,7 +9,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import TextField from '@material-ui/core/TextField';
@@ -41,7 +41,6 @@ const getColorText = (color, disablePlainColor) => {
   } else if (text === 'none') {
     text = color.raw;
   }
-  console.log('colortext=', text, color);
   return text;
 };
 
@@ -60,10 +59,17 @@ const ColorPicker = ({
   disablePlainColor,
 }) => {
   const refPicker = useRef(null);
-  const [open, setOpen] = useState(openAtStart);
+  const [open, setOpen] = useState(false);
   const { t, i18n } = useTranslate();
   const color = ColorTool.validateColor(value, disableAlpha, t, i18n.language, disablePlainColor);
   const raw = getColorText(color, disablePlainColor);
+  
+  useEffect(() => {
+    if (openAtStart) {
+      setOpen(true);
+    }
+  }, [openAtStart]);
+
   const handleClick = () => {
     const b = Boolean(refPicker.current);
     setOpen(b);

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -48,6 +48,7 @@ declare module 'material-ui-color' {
     palette?: any;
     inputFormats?: string[];
     disableAlpha?: boolean;
+    disablePlainColor?: boolean;
     onChange: (color: Color) => void;
     onOpen?: () => void;
     openAtStart?: boolean;

--- a/stories/ColorPicker.stories.js
+++ b/stories/ColorPicker.stories.js
@@ -37,6 +37,11 @@ Basic.story = {
   parameters: { defaultValue: '#000' },
 };
 
+export const OpenAtStart = () => <ColorPicker defaultValue="#000" openAtStart />;
+OpenAtStart.story = {
+  parameters: { defaultValue: '#000', openAtStart: true },
+};
+
 export const DisableAlpha = () => <ColorPicker defaultValue="#000" disableAlpha />;
 DisableAlpha.story = {
   parameters: { defaultValue: '#000', disableAlpha: true },


### PR DESCRIPTION
### Fix issues

- [x] #68

### Description

ColorPicker openAtStart wrong position due to not initialized ref

### Check List

- [x] respect code conventions and usages
- [x] tests and 100% coverage
- [x] well documented
- [x] self review

### Review targets:
- nodejs / npm / yarn