### PR TITLE
feat: when onChange is set it is a controlled component

### DIFF
--- a/src/helpers/uncontrolled.js
+++ b/src/helpers/uncontrolled.js
@@ -16,9 +16,9 @@ const Uncontrolled = ({ element, defaultValue, ...props }) => {
 
 export default Element => {
   const Composite = ({ defaultValue, value, onChange, ...props }) =>
-    defaultValue
+    defaultValue && !onChange
       ? React.createElement(Uncontrolled, { element: Element, defaultValue, ...props })
-      : React.createElement(Element, { value, onChange, ...props });
+      : React.createElement(Element, { value: value || defaultValue, onChange, ...props });
   Composite.propTypes = { ...Element.propTypes, defaultValue: Element.propTypes.value, onChange: PropTypes.func };
   Composite.defaultProps = { ...Element.defaultProps, defaultValue: undefined, onChange: () => {} };
   return Composite;


### PR DESCRIPTION
### Fix issues

- [x] #100

### Description
Some confusion using controlled/uncontrolled. Now if onChange is set, it create a controlled component.

### Check List

- [x] respect code conventions and usages
- [x] tests and 100% coverage
- [x] well documented
- [x] self review

### Review targets:
- nodejs / npm / yarn