### PR TITLE
Support nested themes

### DIFF
--- a/src/components/ColorBox/AlphaSlider.jsx
+++ b/src/components/ColorBox/AlphaSlider.jsx
@@ -5,40 +5,39 @@
  * This source code is licensed under the license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import React from "react";
-import styled from "styled-components";
-import Slider from "@material-ui/core/Slider";
-import { makeStyles } from "@material-ui/core/styles";
+import React from 'react';
+import Slider from '@material-ui/core/Slider';
+import { makeStyles } from '@material-ui/core/styles';
 
 const useStyles = makeStyles({
   root: {
-    color: "#666",
-    width: "100%",
+    color: '#666',
+    width: '100%',
     height: 16,
     padding: 0,
     background:
-      "linear-gradient(45deg, #ccc 25%, transparent 25%), linear-gradient(135deg, #ccc 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #ccc 75%), linear-gradient(135deg, transparent 75%, #ccc 75%)",
-    backgroundColor: "rgba(0, 0, 0, 0)",
-    backgroundPositionX: "0%, 0%, 0%, 0%",
-    backgroundPositionY: "0%, 0%, 0%, 0%",
-    backgroundSize: "auto, auto, auto, auto",
-    backgroundSize: "8px 8px",
-    backgroundColor: "white",
-    backgroundPosition: "0 0, 4px 0, 4px -4px, 0px 4px",
+      'linear-gradient(45deg, #ccc 25%, transparent 25%), linear-gradient(135deg, #ccc 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #ccc 75%), linear-gradient(135deg, transparent 75%, #ccc 75%)',
+    backgroundColor: 'rgba(0, 0, 0, 0)',
+    backgroundPositionX: '0%, 0%, 0%, 0%',
+    backgroundPositionY: '0%, 0%, 0%, 0%',
+    backgroundSize: 'auto, auto, auto, auto',
+    backgroundSize: '8px 8px',
+    backgroundColor: 'white',
+    backgroundPosition: '0 0, 4px 0, 4px -4px, 0px 4px'
   },
 
   rail: {
     height: 16,
     opacity: 1,
-    background: (props) =>
+    background: props =>
       `rgba(0, 0, 0, 0) linear-gradient(to right, ${props.color}00 0%, ${props.color} 100%) repeat scroll 0% 0%`,
-    borderRadius: 0,
+    borderRadius: 0
   },
 
   track: {
     height: 16,
     opacity: 0,
-    borderRadius: 4,
+    borderRadius: 4
   },
 
   thumb: {
@@ -46,13 +45,13 @@ const useStyles = makeStyles({
     height: 16,
     marginTop: 0,
     marginLeft: -8,
-    backgroundColor: "#f0f0f0",
-    boxShadow: "rgba(0, 0, 0, 0.37) 0px 1px 4px 0px",
+    backgroundColor: '#f0f0f0',
+    boxShadow: 'rgba(0, 0, 0, 0.37) 0px 1px 4px 0px',
 
-    "&:focus": {
-      boxShadow: "0px 0px 0px 8px rgba(63, 81, 181, 0.16)",
-    },
-  },
+    '&:focus': {
+      boxShadow: '0px 0px 0px 8px rgba(63, 81, 181, 0.16)'
+    }
+  }
 });
 
 function AlphaSlider({ color, ...rest }) {
@@ -65,7 +64,7 @@ function AlphaSlider({ color, ...rest }) {
         root: classes.root,
         rail: classes.rail,
         track: classes.track,
-        thumb: classes.thumb,
+        thumb: classes.thumb
       }}
     />
   );

--- a/src/components/ColorBox/AlphaSlider.jsx
+++ b/src/components/ColorBox/AlphaSlider.jsx
@@ -5,46 +5,70 @@
  * This source code is licensed under the license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import React from 'react';
-import styled from 'styled-components';
-import Slider from '@material-ui/core/Slider';
+import React from "react";
+import styled from "styled-components";
+import Slider from "@material-ui/core/Slider";
+import { makeStyles } from "@material-ui/core/styles";
 
-// eslint-disable-next-line react/jsx-props-no-spreading
-export default styled(({ color, ...other }) => <Slider {...other} />)`
-  color: #6666;
-  width: 100%;
-  height: 16px;
-  padding: 0;
-  background: linear-gradient(45deg, #ccc 25%, transparent 25%), linear-gradient(135deg, #ccc 25%, transparent 25%),
-    linear-gradient(45deg, transparent 75%, #ccc 75%), linear-gradient(135deg, transparent 75%, #ccc 75%);
-  background-color: rgba(0, 0, 0, 0);
-  background-position-x: 0%, 0%, 0%, 0%;
-  background-position-y: 0%, 0%, 0%, 0%;
-  background-size: auto, auto, auto, auto;
-  background-size: 8px 8px;
-  background-color: white;
-  background-position: 0 0, 4px 0, 4px -4px, 0px 4px;
-  & .MuiSlider-rail {
-    height: 16px;
-    opacity: 1;
-    background: ${props =>
-      `rgba(0, 0, 0, 0) linear-gradient(to right, ${props.color}00 0%, ${props.color} 100%) repeat scroll 0% 0%`};
-    border-radius: 0;
-  }
-  & .MuiSlider-track {
-    height: 16px;
-    opacity: 0;
-    border-radius: 4px;
-  }
-  & .MuiSlider-thumb {
-    width: 16px;
-    height: 16px;
-    margin-top: 0px;
-    margin-left: -8px;
-    background-color: #f0f0f0;
-    box-shadow: rgba(0, 0, 0, 0.37) 0px 1px 4px 0px;
-    &:focus {
-      box-shadow: 0px 0px 0px 8px rgba(63, 81, 181, 0.16);
-    }
-  }
-`;
+const useStyles = makeStyles({
+  root: {
+    color: "#666",
+    width: "100%",
+    height: 16,
+    padding: 0,
+    background:
+      "linear-gradient(45deg, #ccc 25%, transparent 25%), linear-gradient(135deg, #ccc 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #ccc 75%), linear-gradient(135deg, transparent 75%, #ccc 75%)",
+    backgroundColor: "rgba(0, 0, 0, 0)",
+    backgroundPositionX: "0%, 0%, 0%, 0%",
+    backgroundPositionY: "0%, 0%, 0%, 0%",
+    backgroundSize: "auto, auto, auto, auto",
+    backgroundSize: "8px 8px",
+    backgroundColor: "white",
+    backgroundPosition: "0 0, 4px 0, 4px -4px, 0px 4px",
+  },
+
+  rail: {
+    height: 16,
+    opacity: 1,
+    background: (props) =>
+      `rgba(0, 0, 0, 0) linear-gradient(to right, ${props.color}00 0%, ${props.color} 100%) repeat scroll 0% 0%`,
+    borderRadius: 0,
+  },
+
+  track: {
+    height: 16,
+    opacity: 0,
+    borderRadius: 4,
+  },
+
+  thumb: {
+    width: 16,
+    height: 16,
+    marginTop: 0,
+    marginLeft: -8,
+    backgroundColor: "#f0f0f0",
+    boxShadow: "rgba(0, 0, 0, 0.37) 0px 1px 4px 0px",
+
+    "&:focus": {
+      boxShadow: "0px 0px 0px 8px rgba(63, 81, 181, 0.16)",
+    },
+  },
+});
+
+function AlphaSlider({ color, ...rest }) {
+  const classes = useStyles({ color });
+
+  return (
+    <Slider
+      {...rest}
+      classes={{
+        root: classes.root,
+        rail: classes.rail,
+        track: classes.track,
+        thumb: classes.thumb,
+      }}
+    />
+  );
+}
+
+export default AlphaSlider;

--- a/src/components/ColorBox/AlphaSlider.jsx
+++ b/src/components/ColorBox/AlphaSlider.jsx
@@ -8,6 +8,7 @@
 import React from 'react';
 import Slider from '@material-ui/core/Slider';
 import { makeStyles } from '@material-ui/core/styles';
+import * as CommonTypes from '../../helpers/commonTypes';
 
 const useStyles = makeStyles({
   root: {
@@ -17,13 +18,9 @@ const useStyles = makeStyles({
     padding: 0,
     background:
       'linear-gradient(45deg, #ccc 25%, transparent 25%), linear-gradient(135deg, #ccc 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #ccc 75%), linear-gradient(135deg, transparent 75%, #ccc 75%)',
-    backgroundColor: 'rgba(0, 0, 0, 0)',
-    backgroundPositionX: '0%, 0%, 0%, 0%',
-    backgroundPositionY: '0%, 0%, 0%, 0%',
-    backgroundSize: 'auto, auto, auto, auto',
     backgroundSize: '8px 8px',
     backgroundColor: 'white',
-    backgroundPosition: '0 0, 4px 0, 4px -4px, 0px 4px'
+    backgroundPosition: '0 0, 4px 0, 4px -4px, 0px 4px',
   },
 
   rail: {
@@ -31,13 +28,13 @@ const useStyles = makeStyles({
     opacity: 1,
     background: props =>
       `rgba(0, 0, 0, 0) linear-gradient(to right, ${props.color}00 0%, ${props.color} 100%) repeat scroll 0% 0%`,
-    borderRadius: 0
+    borderRadius: 0,
   },
 
   track: {
     height: 16,
     opacity: 0,
-    borderRadius: 4
+    borderRadius: 4,
   },
 
   thumb: {
@@ -49,25 +46,29 @@ const useStyles = makeStyles({
     boxShadow: 'rgba(0, 0, 0, 0.37) 0px 1px 4px 0px',
 
     '&:focus': {
-      boxShadow: '0px 0px 0px 8px rgba(63, 81, 181, 0.16)'
-    }
-  }
+      boxShadow: '0px 0px 0px 8px rgba(63, 81, 181, 0.16)',
+    },
+  },
 });
 
-function AlphaSlider({ color, ...rest }) {
+function AlphaSlider({ color, ...props }) {
   const classes = useStyles({ color });
 
   return (
     <Slider
-      {...rest}
+      // eslint-disable-next-line react/jsx-props-no-spreading
+      {...props}
       classes={{
         root: classes.root,
         rail: classes.rail,
         track: classes.track,
-        thumb: classes.thumb
+        thumb: classes.thumb,
       }}
     />
   );
 }
+AlphaSlider.propTypes = {
+  color: CommonTypes.color.isRequired,
+};
 
 export default AlphaSlider;

--- a/src/components/ColorBox/HueSlider.jsx
+++ b/src/components/ColorBox/HueSlider.jsx
@@ -5,45 +5,60 @@
  * This source code is licensed under the license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import styled from 'styled-components';
-import Slider from '@material-ui/core/Slider';
+import React from "react";
+import Slider from "@material-ui/core/Slider";
+import { makeStyles } from "@material-ui/core/styles";
 
-export default styled(Slider)`
-  width: 100%;
-  height: 16px;
-  padding: 0;
-  & .MuiSlider-rail {
-    height: 16px;
-    opacity: 1;
-    background: rgba(0, 0, 0, 0)
-      linear-gradient(
-        to right,
-        rgb(255, 0, 0) 0%,
-        rgb(255, 255, 0) 17%,
-        rgb(0, 255, 0) 33%,
-        rgb(0, 255, 255) 50%,
-        rgb(0, 0, 255) 67%,
-        rgb(255, 0, 255) 83%,
-        rgb(255, 0, 0) 100%
-      )
-      repeat scroll 0% 0%;
-    border-radius: 0;
-  }
-  & .MuiSlider-track {
-    height: 16px;
-    opacity: 0;
-    border-radius: 4px;
-    background-color: transparent;
-  }
-  & .MuiSlider-thumb {
-    width: 16px;
-    height: 16px;
-    margin-top: 0px;
-    margin-left: -8px;
-    background-color: #f0f0f0;
-    box-shadow: rgba(0, 0, 0, 0.37) 0px 1px 4px 0px;
-    &:focus {
-      box-shadow: 0px 0px 0px 8px rgba(63, 81, 181, 0.16);
-    }
-  }
-`;
+const useStyles = makeStyles(() => ({
+  root: {
+    width: "100%",
+    height: 16,
+    padding: 0,
+  },
+
+  rail: {
+    height: 16,
+    opacity: 1,
+    background:
+      "rgba(0, 0, 0, 0) linear-gradient(to right, rgb(255, 0, 0) 0%, rgb(255, 255, 0) 17%, rgb(0, 255, 0) 33%, rgb(0, 255, 255) 50%, rgb(0, 0, 255) 67%, rgb(255, 0, 255) 83%, rgb(255, 0, 0) 100% ) repeat scroll 0% 0%",
+    borderRadius: 0,
+  },
+
+  track: {
+    height: 16,
+    opacity: 0,
+    borderRadius: 4,
+    backgroundColor: "transparent",
+  },
+
+  thumb: {
+    width: 16,
+    height: 16,
+    marginTop: 0,
+    marginLeft: -8,
+    backgroundColor: "#f0f0f0",
+    boxShadow: "rgba(0, 0, 0, 0.37) 0px 1px 4px 0px",
+
+    "&:focus": {
+      boxShadow: "0px 0px 0px 8px rgba(63, 81, 181, 0.16)",
+    },
+  },
+}));
+
+function HueSlider(props) {
+  const classes = useStyles();
+
+  return (
+    <Slider
+      {...props}
+      classes={{
+        root: classes.root,
+        rail: classes.rail,
+        track: classes.track,
+        thumb: classes.thumb,
+      }}
+    />
+  );
+}
+
+export default HueSlider;

--- a/src/components/ColorBox/HueSlider.jsx
+++ b/src/components/ColorBox/HueSlider.jsx
@@ -5,30 +5,30 @@
  * This source code is licensed under the license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import React from "react";
-import Slider from "@material-ui/core/Slider";
-import { makeStyles } from "@material-ui/core/styles";
+import React from 'react';
+import Slider from '@material-ui/core/Slider';
+import { makeStyles } from '@material-ui/core/styles';
 
 const useStyles = makeStyles(() => ({
   root: {
-    width: "100%",
+    width: '100%',
     height: 16,
-    padding: 0,
+    padding: 0
   },
 
   rail: {
     height: 16,
     opacity: 1,
     background:
-      "rgba(0, 0, 0, 0) linear-gradient(to right, rgb(255, 0, 0) 0%, rgb(255, 255, 0) 17%, rgb(0, 255, 0) 33%, rgb(0, 255, 255) 50%, rgb(0, 0, 255) 67%, rgb(255, 0, 255) 83%, rgb(255, 0, 0) 100% ) repeat scroll 0% 0%",
-    borderRadius: 0,
+      'rgba(0, 0, 0, 0) linear-gradient(to right, rgb(255, 0, 0) 0%, rgb(255, 255, 0) 17%, rgb(0, 255, 0) 33%, rgb(0, 255, 255) 50%, rgb(0, 0, 255) 67%, rgb(255, 0, 255) 83%, rgb(255, 0, 0) 100% ) repeat scroll 0% 0%',
+    borderRadius: 0
   },
 
   track: {
     height: 16,
     opacity: 0,
     borderRadius: 4,
-    backgroundColor: "transparent",
+    backgroundColor: 'transparent'
   },
 
   thumb: {
@@ -36,13 +36,13 @@ const useStyles = makeStyles(() => ({
     height: 16,
     marginTop: 0,
     marginLeft: -8,
-    backgroundColor: "#f0f0f0",
-    boxShadow: "rgba(0, 0, 0, 0.37) 0px 1px 4px 0px",
+    backgroundColor: '#f0f0f0',
+    boxShadow: 'rgba(0, 0, 0, 0.37) 0px 1px 4px 0px',
 
-    "&:focus": {
-      boxShadow: "0px 0px 0px 8px rgba(63, 81, 181, 0.16)",
-    },
-  },
+    '&:focus': {
+      boxShadow: '0px 0px 0px 8px rgba(63, 81, 181, 0.16)'
+    }
+  }
 }));
 
 function HueSlider(props) {
@@ -55,7 +55,7 @@ function HueSlider(props) {
         root: classes.root,
         rail: classes.rail,
         track: classes.track,
-        thumb: classes.thumb,
+        thumb: classes.thumb
       }}
     />
   );

--- a/src/components/ColorBox/HueSlider.jsx
+++ b/src/components/ColorBox/HueSlider.jsx
@@ -13,7 +13,7 @@ const useStyles = makeStyles(() => ({
   root: {
     width: '100%',
     height: 16,
-    padding: 0
+    padding: 0,
   },
 
   rail: {
@@ -21,14 +21,14 @@ const useStyles = makeStyles(() => ({
     opacity: 1,
     background:
       'rgba(0, 0, 0, 0) linear-gradient(to right, rgb(255, 0, 0) 0%, rgb(255, 255, 0) 17%, rgb(0, 255, 0) 33%, rgb(0, 255, 255) 50%, rgb(0, 0, 255) 67%, rgb(255, 0, 255) 83%, rgb(255, 0, 0) 100% ) repeat scroll 0% 0%',
-    borderRadius: 0
+    borderRadius: 0,
   },
 
   track: {
     height: 16,
     opacity: 0,
     borderRadius: 4,
-    backgroundColor: 'transparent'
+    backgroundColor: 'transparent',
   },
 
   thumb: {
@@ -40,9 +40,9 @@ const useStyles = makeStyles(() => ({
     boxShadow: 'rgba(0, 0, 0, 0.37) 0px 1px 4px 0px',
 
     '&:focus': {
-      boxShadow: '0px 0px 0px 8px rgba(63, 81, 181, 0.16)'
-    }
-  }
+      boxShadow: '0px 0px 0px 8px rgba(63, 81, 181, 0.16)',
+    },
+  },
 }));
 
 function HueSlider(props) {
@@ -50,12 +50,13 @@ function HueSlider(props) {
 
   return (
     <Slider
+      // eslint-disable-next-line react/jsx-props-no-spreading
       {...props}
       classes={{
         root: classes.root,
         rail: classes.rail,
         track: classes.track,
-        thumb: classes.thumb
+        thumb: classes.thumb,
       }}
     />
   );


### PR DESCRIPTION
### Fix issues

- [ ] #83 

### Description

When using [theme nesting](https://material-ui.com/styles/advanced/#theme-nesting), material-ui class names are generated with an identifier at the end (MuiSlider-rail-109, MuiSlider-track-200) and this affected some styles for HueSlider and AlphaSlider, because the styling was made specifically for MuiSlider-rail or MuiSlider-track. So, giving them specific class names generated through their makeStyles utility function, we can avoid that.

Here is a sandbox with the problem reproduced: https://codesandbox.io/s/material-ui-color-themeprovider-2rfdj

### Check List

- [x] respect code conventions and usages
- [x] tests and 100% coverage
- [x] well documented
- [x] self review

### Review targets:
- nodejs / npm / yarn