### PR TITLE
Fix husky hooks on fresh clone

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "lint": "eslint src",
     "test": "cross-env NODE_ENV=test  jest",
     "coverage": "cross-env NODE_ENV=test  jest --coverage --colors",
-    "prepublishOnly": "yarn build"
+    "prepublishOnly": "yarn build",
+    "prepare": "husky install"
   },
   "devDependencies": {
     "@babel/core": "^7.8.4",

--- a/package.json
+++ b/package.json
@@ -1,16 +1,16 @@
 {
-	"name": "material-ui-color",
-	"version": "0.4.11",
-	"description": "The lightest colorpicker for React Material-Ui. No dependencies. It uses Hooks and support Typescript, and more !",
-	"main": "index.js",
-	"module": "./esm/index.js",
-	"typings": "index.d.ts",
-	"homepage": "https://mikbry.github.io/material-ui-color/",
-	"repository": "https://github.com/mikbry/material-ui-color.git",
-	"bugs": "https://github.com/mikbry/material-ui-color/issues",
-	"author": "Mik <mik@miklabs.com>",
-	"license": "MIT",
-	"keywords": [
+  "name": "material-ui-color",
+  "version": "0.4.11",
+  "description": "The lightest colorpicker for React Material-Ui. No dependencies. It uses Hooks and support Typescript, and more !",
+  "main": "index.js",
+  "module": "./esm/index.js",
+  "typings": "index.d.ts",
+  "homepage": "https://mikbry.github.io/material-ui-color/",
+  "repository": "https://github.com/mikbry/material-ui-color.git",
+  "bugs": "https://github.com/mikbry/material-ui-color/issues",
+  "author": "Mik <mik@miklabs.com>",
+  "license": "MIT",
+  "keywords": [
     "react",
     "color picker",
     "react-component",
@@ -21,7 +21,7 @@
     "material-ui",
     "material design",
     "react-color",
-		"typescript"
+    "typescript"
   ],
   "scripts": {
     "clean": "rimraf dist && mkdir dist",


### PR DESCRIPTION
### Fix issues

- new issue

### Description

On fresh git clone repo, the husky hooks aren't installed and therefore commits are not accepted. Somehow in  #112 on updating husky these hooks were installed, but aren't updated on a fresh clone.
See also: https://typicode.github.io/husky/#/?id=install

### Check List

- [x] respect code conventions and usages
- [x] tests and 100% coverage
- [x] well documented
- [x] self review

### Review targets:
- yarn / npm / git hooks