### PR TITLE
Fix boolean logic for inputFormats in ColorBox

### DIFF
--- a/src/components/ColorBox/index.jsx
+++ b/src/components/ColorBox/index.jsx
@@ -146,7 +146,7 @@ const ColorBox = ({ value, palette, inputFormats, deferred, onChange: _onChange,
   };
 
   const displayInput = () =>
-    inputFormats && (
+    inputFormats.length > 0 && (
       <div className={`muicc-colorbox-inputs  ${classes.colorboxInputs}`}>
         <div className={`muicc-colorbox-colorBg ${classes.colorboxColorBg}`}>
           <div className={`muicc-colorbox-color ${classes.colorboxColor}`} />


### PR DESCRIPTION
### Fix issues
- [x] Closes #147  

### Description

Simply changed the condition to check that the length of the inputFormats array is greater than 0 since an array in Javascript will always return true even if empty.

### Check List

- [x] respect code conventions and usages
- [x] tests and 100% coverage
- [x] well documented
- [x] self review

### Review targets:
- nodejs / npm / yarn