### PR TITLE
Add HSL gradient option

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,7 +4,6 @@
     "airbnb",
     "plugin:import/errors",
     "prettier",
-    "prettier/react"
   ],
   "parserOptions": {
     "ecmaVersion": 11,
@@ -52,6 +51,7 @@
       "error",
       {
         "trailingComma": "all",
+        "arrowParens": "avoid",
         "singleQuote": true,
         "printWidth": 120
       }

--- a/src/components/ColorBox/HSVGradient.jsx
+++ b/src/components/ColorBox/HSVGradient.jsx
@@ -52,6 +52,13 @@ const useStyles = makeStyles({
   hsvGradientV: {
     background: 'rgba(0, 0, 0, 0) linear-gradient(to top, rgb(0, 0, 0), rgba(0, 0, 0, 0)) repeat scroll 0% 0%',
   },
+  hslGradientS: {
+    background:
+      'rgba(0, 0, 0, 0) linear-gradient(to right, rgb(128, 128, 128), rgba(255, 255, 255, 0)) repeat scroll 0% 0%',
+  },
+  hslGradientL: {
+    background: 'rgba(0, 0, 0, 0) linear-gradient(to top, rgb(0, 0, 0), rgba(128, 128, 128, 0), rgb(255, 255, 255)) repeat scroll 0% 0%',
+  },
   hsvGradientCursor: {
     position: 'absolute',
     top: 0,
@@ -84,7 +91,7 @@ const useStyles = makeStyles({
   },
 });
 
-const HSVGradient = ({ className, color, onChange, ...props }) => {
+const HSVGradient = ({ className, color, onChange, isHsl=false, ...props }) => {
   const latestColor = React.useRef(color);
   const [focus, onFocus] = React.useState(false);
   const [pressed, setPressed] = React.useState(false);
@@ -109,10 +116,11 @@ const HSVGradient = ({ className, color, onChange, ...props }) => {
 
   const initPosition = ref => {
     if (ref) {
-      const { hsv } = color;
+      const { hsv, hsl } = color;
+      const hsx = (isHsl ? hsl : hsv)
       cursorPos = {
-        x: Math.round((hsv[1] / 100) * (ref.clientWidth - 1)),
-        y: Math.round((1 - hsv[2] / 100) * (ref.clientHeight - 1)),
+        x: Math.round((hsx[1] / 100) * (ref.clientWidth - 1)),
+        y: Math.round((1 - hsx[2] / 100) * (ref.clientHeight - 1)),
       };
       setPosition(cursorPos);
     }
@@ -224,8 +232,8 @@ const HSVGradient = ({ className, color, onChange, ...props }) => {
   return (
     <div className={className}>
       <div className={classes.root} {...props} ref={box} data-testid="hsvgradient-color">
-        <div className={`muicc-hsvgradient-s ${classes.hsvGradientS} ${classes.gradientPosition}`}>
-          <div className={`muicc-hsvgradient-v ${classes.hsvGradientV} ${classes.gradientPosition}`}>
+        <div className={`muicc-hsvgradient-s ${isHsl ? classes.hslGradientS : classes.hsvGradientS} ${classes.gradientPosition}`}>
+          <div className={`muicc-hsvgradient-v ${isHsl ? classes.hslGradientL : classes.hsvGradientV} ${classes.gradientPosition}`}>
             <div
               ref={cursor}
               tabIndex="0"
@@ -253,6 +261,7 @@ HSVGradient.propTypes = {
   color: CommonTypes.color.isRequired,
   className: PropTypes.string.isRequired,
   onChange: PropTypes.func.isRequired,
+  isHsl: PropTypes.bool
 };
 
 export default HSVGradient;

--- a/src/components/ColorBox/HSVGradient.jsx
+++ b/src/components/ColorBox/HSVGradient.jsx
@@ -57,7 +57,8 @@ const useStyles = makeStyles({
       'rgba(0, 0, 0, 0) linear-gradient(to right, rgb(128, 128, 128), rgba(255, 255, 255, 0)) repeat scroll 0% 0%',
   },
   hslGradientL: {
-    background: 'rgba(0, 0, 0, 0) linear-gradient(to top, rgb(0, 0, 0), rgba(128, 128, 128, 0), rgb(255, 255, 255)) repeat scroll 0% 0%',
+    background:
+      'rgba(0, 0, 0, 0) linear-gradient(to top, rgb(0, 0, 0), rgba(128, 128, 128, 0), rgb(255, 255, 255)) repeat scroll 0% 0%',
   },
   hsvGradientCursor: {
     position: 'absolute',
@@ -91,7 +92,7 @@ const useStyles = makeStyles({
   },
 });
 
-const HSVGradient = ({ className, color, onChange, isHsl=false, ...props }) => {
+const HSVGradient = ({ className, color, onChange, isHsl, ...props }) => {
   const latestColor = React.useRef(color);
   const [focus, onFocus] = React.useState(false);
   const [pressed, setPressed] = React.useState(false);
@@ -117,7 +118,7 @@ const HSVGradient = ({ className, color, onChange, isHsl=false, ...props }) => {
   const initPosition = ref => {
     if (ref) {
       const { hsv, hsl } = color;
-      const hsx = (isHsl ? hsl : hsv)
+      const hsx = isHsl ? hsl : hsv;
       cursorPos = {
         x: Math.round((hsx[1] / 100) * (ref.clientWidth - 1)),
         y: Math.round((1 - hsx[2] / 100) * (ref.clientHeight - 1)),
@@ -232,8 +233,16 @@ const HSVGradient = ({ className, color, onChange, isHsl=false, ...props }) => {
   return (
     <div className={className}>
       <div className={classes.root} {...props} ref={box} data-testid="hsvgradient-color">
-        <div className={`muicc-hsvgradient-s ${isHsl ? classes.hslGradientS : classes.hsvGradientS} ${classes.gradientPosition}`}>
-          <div className={`muicc-hsvgradient-v ${isHsl ? classes.hslGradientL : classes.hsvGradientV} ${classes.gradientPosition}`}>
+        <div
+          className={`muicc-hsvgradient-s ${isHsl ? classes.hslGradientS : classes.hsvGradientS} ${
+            classes.gradientPosition
+          }`}
+        >
+          <div
+            className={`muicc-hsvgradient-v ${isHsl ? classes.hslGradientL : classes.hsvGradientV} ${
+              classes.gradientPosition
+            }`}
+          >
             <div
               ref={cursor}
               tabIndex="0"
@@ -261,7 +270,11 @@ HSVGradient.propTypes = {
   color: CommonTypes.color.isRequired,
   className: PropTypes.string.isRequired,
   onChange: PropTypes.func.isRequired,
-  isHsl: PropTypes.bool
+  isHsl: PropTypes.bool,
+};
+
+HSVGradient.defaultProps = {
+  isHsl: false,
 };
 
 export default HSVGradient;

--- a/src/components/ColorBox/index.jsx
+++ b/src/components/ColorBox/index.jsx
@@ -95,7 +95,7 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-const ColorBox = ({ value, palette, inputFormats, deferred, onChange: _onChange, disableAlpha, ...props }) => {
+const ColorBox = ({ value, palette, inputFormats, deferred, onChange: _onChange, disableAlpha, hslGradient, ...props }) => {
   const { t, i18n } = useTranslate();
   let color = validateColor(value, disableAlpha, t, i18n.language);
   let onChange = _onChange;
@@ -129,7 +129,7 @@ const ColorBox = ({ value, palette, inputFormats, deferred, onChange: _onChange,
   };
 
   const handleSVChange = hsvVal => {
-    const c = colorParse(hsvVal, 'hsv');
+    const c = colorParse(hsvVal, hslGradient ? 'hsl' : 'hsv');
     onChange(c);
   };
 
@@ -172,6 +172,7 @@ const ColorBox = ({ value, palette, inputFormats, deferred, onChange: _onChange,
           className={`muicc-colorbox-hsvgradient ${classes.colorboxHsvGradient}`}
           color={color}
           onChange={handleSVChange}
+          isHsl={hslGradient}
         />
         <div className={`muicc-colorbox-sliders ${classes.colorboxSliders}`}>
           <HueSlider
@@ -230,6 +231,7 @@ ColorBox.propTypes = {
     Don't use alpha
    */
   disableAlpha: PropTypes.bool,
+  hslGradient: PropTypes.bool,
 };
 
 ColorBox.defaultProps = {
@@ -238,6 +240,7 @@ ColorBox.defaultProps = {
   palette: undefined,
   inputFormats: ['hex', 'rgb'],
   disableAlpha: false,
+  hslGradient: false,
 };
 
 export default uncontrolled(ColorBox);

--- a/src/components/ColorPicker.jsx
+++ b/src/components/ColorPicker.jsx
@@ -61,6 +61,7 @@ const ColorPicker = ({
   onOpen,
   doPopup,
   disableAlpha,
+  hslGradient,
   hideTextfield,
   disablePlainColor,
 }) => {
@@ -107,6 +108,7 @@ const ColorPicker = ({
       palette={palette}
       inputFormats={inputFormats}
       disableAlpha={disableAlpha}
+      hslGradient={hslGradient}
       onChange={handleColorChange}
     />
   );
@@ -174,6 +176,7 @@ ColorPicker.propTypes = {
     Don't use alpha
    */
   disableAlpha: PropTypes.bool,
+  hslGradient: PropTypes.bool,
   hideTextfield: PropTypes.bool,
   disablePlainColor: PropTypes.bool,
 };
@@ -188,6 +191,7 @@ ColorPicker.defaultProps = {
   openAtStart: false,
   doPopup: undefined,
   disableAlpha: false,
+  hslGradient: false,
   hideTextfield: false,
   disablePlainColor: false,
 };

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -116,6 +116,7 @@ declare module 'material-ui-color' {
     palette?: Record<string, string>;
     inputFormats?: ColorFormat[];
     onChange: (color: Color) => void;
+    disableAlpha?: boolean;
     hslGradient?: boolean;
   }
 

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -49,13 +49,14 @@ declare module 'material-ui-color' {
     hideTextfield?: boolean;
     deferred?: boolean;
     palette?: any;
-    inputFormats?: string[];
+    inputFormats?: ColorFormat[];
     disableAlpha?: boolean;
     disablePlainColor?: boolean;
     onChange: (color: Color) => void;
     onOpen?: () => void;
     openAtStart?: boolean;
     doPopup?: () => void;
+    hslGradient?: boolean;
   }
   interface ColorPickerPaletteProps<T extends PaletteRecord | null> extends ColorPickerProps {
     palette?: T;
@@ -113,8 +114,9 @@ declare module 'material-ui-color' {
     value?: ColorValue;
     deferred?: boolean;
     palette?: Record<string, string>;
-    inputFormats?: string[];
+    inputFormats?: ColorFormat[];
     onChange: (color: Color) => void;
+    hslGradient?: boolean;
   }
 
   function ColorBox(props: ColorBoxProps): JSX.Element;

--- a/stories/ColorPicker.stories.js
+++ b/stories/ColorPicker.stories.js
@@ -48,7 +48,7 @@ DisableAlpha.story = {
 };
 
 export const HslGradient = () => <ColorPicker defaultValue="#000" hslGradient />;
-DisableAlpha.story = {
+HslGradient.story = {
   parameters: { defaultValue: '#000', hslGradient: true },
 };
 

--- a/stories/ColorPicker.stories.js
+++ b/stories/ColorPicker.stories.js
@@ -47,6 +47,11 @@ DisableAlpha.story = {
   parameters: { defaultValue: '#000', disableAlpha: true },
 };
 
+export const HslGradient = () => <ColorPicker defaultValue="#000" hslGradient />;
+DisableAlpha.story = {
+  parameters: { defaultValue: '#000', hslGradient: true },
+};
+
 export const DisablePlain = () => <ColorPicker defaultValue="#000" disablePlainColor />;
 DisablePlain.story = {
   parameters: { defaultValue: '#000', disablePlainColor: true },

--- a/test/ColorBox.test.js
+++ b/test/ColorBox.test.js
@@ -103,6 +103,27 @@ test('ColorBox props', async () => {
   expect(span).toHaveStyle('left: 49%');
 });
 
+test('ColorBox HSL props', async () => {
+  const {  findByTestId } = render(<ColorBox defaultValue="#830A0A7D" hslGradient />);
+  let component = await findByTestId('hsvgradient-color');
+  expect(component).toHaveStyle({ background: 'rgb(255, 0, 0) none repeat scroll 0%' });
+  component = await findByTestId('hsvgradient-cursor');
+  expect(component).toHaveStyle({
+    left: '264px',
+    top: '83px',
+  });
+  component = await findByTestId('hueslider');
+  let span = component.querySelector('.MuiSlider-track');
+  expect(span).toHaveStyle('width: 0%');
+  span = component.querySelector('.MuiSlider-thumb');
+  expect(span).toHaveStyle('left: 0%');
+  component = await findByTestId('alphaslider');
+  span = component.querySelector('.MuiSlider-track');
+  expect(span).toHaveStyle('width: 49%');
+  span = component.querySelector('.MuiSlider-thumb');
+  expect(span).toHaveStyle('left: 49%');
+});
+
 test('ColorBox palette onChange', () => {
   let value;
   const onChange = jest.fn().mockImplementation(newValue => {
@@ -196,6 +217,128 @@ test('ColorBox hsvgradient cursor changes', async () => {
   );
   expect(onChange).toHaveBeenCalledTimes(1);
   expect(value.name).toBe('white');
+});
+
+test('ColorBox hslgradient cursor changes', async () => {
+  let value;
+  const onChange = jest.fn().mockImplementation(newValue => {
+    value = newValue;
+  });
+  const { findByTestId } = render(<ColorBox value="#7A0E30" onChange={onChange} hslGradient />);
+  let component = await findByTestId('hsvgradient-color');
+  expect(component.clientWidth).toEqual(308);
+  expect(component.clientHeight).toEqual(116);
+  expect(component.getBoundingClientRect()).toEqual({ left: 22, top: 90 });
+  expect(component).toHaveStyle({ background: 'rgb(255, 0, 81) none repeat scroll 0%' });
+  component = await findByTestId('hsvgradient-cursor');
+  expect(component).toHaveStyle({
+    left: '243px',
+    top: '84px',
+  });
+  expect(value).toBe(undefined);
+  fireEvent(
+    component,
+    new FakeMouseEvent('mousedown', {
+      bubbles: true,
+    }),
+  );
+  expect(onChange).toHaveBeenCalledTimes(0);
+  expect(value).toBe(undefined);
+  fireEvent(
+    component,
+    new FakeMouseEvent('mouseup', {
+      bubbles: true,
+      pageX: 0,
+      pageY: 0,
+    }),
+  );
+  expect(onChange).toHaveBeenCalledTimes(1);
+  expect(value.name).toBe('white');
+  fireEvent(
+    component,
+    new FakeMouseEvent('mousedown', {
+      bubbles: true,
+    }),
+  );
+  expect(onChange).toHaveBeenCalledTimes(1);
+  fireEvent(
+    component,
+    new FakeMouseEvent('mouseup', {
+      bubbles: true,
+      pageX: 0,
+      pageY: 600,
+    }),
+  );
+  expect(onChange).toHaveBeenCalledTimes(2);
+  expect(value.name).toBe('black');
+  fireEvent(
+    component,
+    new FakeMouseEvent('mousedown', {
+      bubbles: true,
+    }),
+  );
+  expect(onChange).toHaveBeenCalledTimes(2);
+  fireEvent(
+    component,
+    new FakeMouseEvent('mouseup', {
+      bubbles: true,
+      pageX: 500,
+      pageY: 600,
+    }),
+  );
+  expect(onChange).toHaveBeenCalledTimes(3);
+  expect(value.name).toBe('black');
+  fireEvent(
+    component,
+    new FakeMouseEvent('mousedown', {
+      bubbles: true,
+    }),
+  );
+  expect(onChange).toHaveBeenCalledTimes(3);
+  fireEvent(
+    component,
+    new FakeMouseEvent('mouseup', {
+      bubbles: true,
+      pageX: 500,
+      pageY: 0,
+    }),
+  );
+  expect(onChange).toHaveBeenCalledTimes(4);
+  expect(value.name).toBe('white');
+  fireEvent(
+    component,
+    new FakeMouseEvent('mousedown', {
+      bubbles: true,
+    }),
+  );
+  expect(onChange).toHaveBeenCalledTimes(4);
+  fireEvent(
+    component,
+    new FakeMouseEvent('mouseup', {
+      bubbles: true,
+      pageX: 500,
+      pageY: 147.5,
+    }),
+  );
+  expect(onChange).toHaveBeenCalledTimes(5);
+  expect(value.hex).toBe('FF0051');
+  fireEvent(
+    component,
+    new FakeMouseEvent('mousedown', {
+      bubbles: true,
+    }),
+  );
+  expect(onChange).toHaveBeenCalledTimes(5);
+  fireEvent(
+    component,
+    new FakeMouseEvent('mouseup', {
+      bubbles: true,
+      pageX: 0,
+      pageY: 147.5,
+    }),
+  );
+  expect(onChange).toHaveBeenCalledTimes(6);
+  expect(value.hex).toBe('808080');
 });
 
 test('ColorBox hsvgradient touch move', async () => {


### PR DESCRIPTION
### Description

Add a `isHsl` prop  to HSVGradient, and a corresponding `hslGradient` prop to ColorBox and ColorPicker, that changes the 2D gradient to a HSL one insead of a HSV gradient.
### Check List

- [x] respect code conventions and usages
- [x] tests and 100% coverage
- [x] well documented
- [x] self review
