### PR TITLE
fix: error in type for useTranslate

### DIFF
--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -123,18 +123,13 @@ declare module 'material-ui-color' {
   interface i18n {
     language: string;
   }
-
-  interface TranslationProps {
-    t: typeof TFunction,
-    i18n?: i18n;
-  }
   
   interface Translation {
     t: typeof TFunction,
     i18n?: i18n;
   }
 
-  function useTranslate(translation: TranslationProps): Translation;
+  function useTranslate(translation: () => Translation): Translation;
 
   function createColor(raw: Raw, format?: ColorFormat, disableAlpha?: boolean): Color;
 


### PR DESCRIPTION
### Description

useTranslate expect a funciton which return a Translation object , not a TranslationProps Object.

### Check List

- [x] respect code conventions and usages
- [x] tests and 100% coverage
- [x] well documented
- [x] self review

### Review targets:
- nodejs / npm / yarn