### PR TITLE
Remove TranslationProps in exports.

### DIFF
--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -123,18 +123,13 @@ declare module 'material-ui-color' {
   interface i18n {
     language: string;
   }
-
-  interface TranslationProps {
-    t: typeof TFunction,
-    i18n?: i18n;
-  }
   
   interface Translation {
     t: typeof TFunction,
     i18n?: i18n;
   }
 
-  function useTranslate(translation: TranslationProps): Translation;
+  function useTranslate(translation: () => Translation): Translation;
 
   function createColor(raw: Raw, format?: ColorFormat, disableAlpha?: boolean): Color;
 

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -150,7 +150,6 @@ declare module 'material-ui-color' {
     ColorValue,
     Raw,
     i18n,
-    TranslationProps,
     Translation,
     useTranslate,
     createColor,


### PR DESCRIPTION
### Description
I just found I forgot to remove `TranslationProps` in export which was removed in #156
Apologize for my mistake.
### Review targets:
- nodejs / npm / yarn