### PR TITLE
update color when moving cursor

### DIFF
--- a/src/components/ColorBox/HSVGradient.jsx
+++ b/src/components/ColorBox/HSVGradient.jsx
@@ -87,7 +87,7 @@ const useStyles = makeStyles({
 const HSVGradient = ({ className, color, onChange, ...props }) => {
   const latestColor = React.useRef(color);
   const [focus, onFocus] = React.useState(false);
-  const [pressed, setPressed] = React.useState(false);
+  const pressed = React.useRef(false);
   React.useEffect(() => {
     latestColor.current = color;
   });
@@ -150,17 +150,17 @@ const HSVGradient = ({ className, color, onChange, ...props }) => {
     initPosition(ref);
     const handleDown = event => {
       onFocus(true);
-      setPressed(true);
+      pressed.current = true;
       event.preventDefault();
     };
     const handleUp = event => {
       const xy = { x: event.pageX - window.scrollX, y: event.pageY - window.scrollY };
       convertMousePosition(xy, ref);
-      setPressed(false);
+      pressed.current = false;
       event.preventDefault();
     };
     const handleMove = event => {
-      if (pressed && event.buttons) {
+      if (pressed.current && event.buttons) {
         const xy = { x: event.pageX - window.scrollX, y: event.pageY - window.scrollY };
         convertMousePosition(xy, ref);
         event.preventDefault();
@@ -233,7 +233,7 @@ const HSVGradient = ({ className, color, onChange, ...props }) => {
               aria-valuemax={100}
               aria-valuemin={0}
               aria-valuenow={color.hsv[1]}
-              pressed={`${pressed}`}
+              pressed={`${pressed.current}`}
               data-testid="hsvgradient-cursor"
               className={`muicc-hsvgradient-cursor ${classes.hsvGradientCursor}`}
               onKeyDown={handleKey}

--- a/test/ColorBox.test.js
+++ b/test/ColorBox.test.js
@@ -194,7 +194,7 @@ test('ColorBox hsvgradient cursor changes', async () => {
       pageY: -600,
     }),
   );
-  expect(onChange).toHaveBeenCalledTimes(1);
+  expect(onChange).toHaveBeenCalledTimes(3);
   expect(value.name).toBe('white');
 });
 


### PR DESCRIPTION
### Description

The cursor currently doesn't move when dragging it in the HSV gradient, this doesn't look intentional and the result of a `useEffect` with missing dependencies bug.
This makes the cursor move and the color be updated during the drag
### Check List

- [x] respect code conventions and usages
- [x] tests and 100% coverage
- [x] well documented
- [x] self review
