### PR TITLE
Invert HSL gradient axes

### DIFF
--- a/src/components/ColorBox/HSVGradient.jsx
+++ b/src/components/ColorBox/HSVGradient.jsx
@@ -54,11 +54,11 @@ const useStyles = makeStyles({
   },
   hslGradientS: {
     background:
-      'rgba(0, 0, 0, 0) linear-gradient(to right, rgb(128, 128, 128), rgba(255, 255, 255, 0)) repeat scroll 0% 0%',
+      'rgba(0, 0, 0, 0) linear-gradient(to bottom, rgb(128, 128, 128), rgba(255, 255, 255, 0)) repeat scroll 0% 0%',
   },
   hslGradientL: {
     background:
-      'rgba(0, 0, 0, 0) linear-gradient(to top, rgb(0, 0, 0), rgba(128, 128, 128, 0), rgb(255, 255, 255)) repeat scroll 0% 0%',
+      'rgba(0, 0, 0, 0) linear-gradient(to left, rgb(0, 0, 0), rgba(128, 128, 128, 0), rgb(255, 255, 255)) repeat scroll 0% 0%',
   },
   hsvGradientCursor: {
     position: 'absolute',
@@ -118,10 +118,9 @@ const HSVGradient = ({ className, color, onChange, isHsl, ...props }) => {
   const initPosition = ref => {
     if (ref) {
       const { hsv, hsl } = color;
-      const hsx = isHsl ? hsl : hsv;
       cursorPos = {
-        x: Math.round((hsx[1] / 100) * (ref.clientWidth - 1)),
-        y: Math.round((1 - hsx[2] / 100) * (ref.clientHeight - 1)),
+        x: Math.round(((isHsl ? 100 - hsl[2] : hsv[1]) / 100) * (ref.clientWidth - 1)),
+        y: Math.round(((isHsl ? hsl[1] : 100 - hsv[2]) / 100) * (ref.clientHeight - 1)),
       };
       setPosition(cursorPos);
     }
@@ -148,10 +147,16 @@ const HSVGradient = ({ className, color, onChange, isHsl, ...props }) => {
       pos.y = ref.clientHeight - 1;
     }
     setPosition(pos, true);
-    const s = (pos.x / (ref.clientWidth - 1)) * 100;
-    const v = (1 - pos.y / (ref.clientHeight - 1)) * 100;
     const c = latestColor.current;
-    onChange([c.hsv[0], s, v]);
+    if (isHsl) {
+      const s = (pos.y / (ref.clientHeight - 1)) * 100;
+      const l = (1 - pos.x / (ref.clientWidth - 1)) * 100;
+      onChange([c.hsl[0], s, l]);
+    } else {
+      const s = (pos.x / (ref.clientWidth - 1)) * 100;
+      const v = (1 - pos.y / (ref.clientHeight - 1)) * 100;
+      onChange([c.hsv[0], s, v]);
+    }
   };
 
   React.useEffect(() => {

--- a/src/components/ColorBox/index.jsx
+++ b/src/components/ColorBox/index.jsx
@@ -95,7 +95,16 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-const ColorBox = ({ value, palette, inputFormats, deferred, onChange: _onChange, disableAlpha, hslGradient, ...props }) => {
+const ColorBox = ({
+  value,
+  palette,
+  inputFormats,
+  deferred,
+  onChange: _onChange,
+  disableAlpha,
+  hslGradient,
+  ...props
+}) => {
   const { t, i18n } = useTranslate();
   let color = validateColor(value, disableAlpha, t, i18n.language);
   let onChange = _onChange;
@@ -105,7 +114,7 @@ const ColorBox = ({ value, palette, inputFormats, deferred, onChange: _onChange,
     onDeferredChange = _onChange;
   }
 
-  const { hsv } = color;
+  const { hsv, hsl } = color;
   let { alpha } = color;
   alpha = alpha === undefined ? 100 : Math.floor(alpha * 100);
   const cssColor = getCssColor(color, 'hex', true);
@@ -178,7 +187,7 @@ const ColorBox = ({ value, palette, inputFormats, deferred, onChange: _onChange,
           <HueSlider
             data-testid="hueslider"
             aria-label="color slider"
-            value={hsv[0]}
+            value={hslGradient ? hsl[0] : hsv[0]}
             min={0}
             max={360}
             onChange={handleHueChange}

--- a/test/ColorBox.test.js
+++ b/test/ColorBox.test.js
@@ -104,13 +104,13 @@ test('ColorBox props', async () => {
 });
 
 test('ColorBox HSL props', async () => {
-  const {  findByTestId } = render(<ColorBox defaultValue="#830A0A7D" hslGradient />);
+  const { findByTestId } = render(<ColorBox defaultValue="#830A0A7D" hslGradient />);
   let component = await findByTestId('hsvgradient-color');
   expect(component).toHaveStyle({ background: 'rgb(255, 0, 0) none repeat scroll 0%' });
   component = await findByTestId('hsvgradient-cursor');
   expect(component).toHaveStyle({
-    left: '264px',
-    top: '83px',
+    left: '221px',
+    top: '99px',
   });
   component = await findByTestId('hueslider');
   let span = component.querySelector('.MuiSlider-track');
@@ -226,14 +226,18 @@ test('ColorBox hslgradient cursor changes', async () => {
   });
   const { findByTestId } = render(<ColorBox value="#7A0E30" onChange={onChange} hslGradient />);
   let component = await findByTestId('hsvgradient-color');
-  expect(component.clientWidth).toEqual(308);
-  expect(component.clientHeight).toEqual(116);
-  expect(component.getBoundingClientRect()).toEqual({ left: 22, top: 90 });
+  const left = 22;
+  const top = 90;
+  const width = 308;
+  const height = 116;
+  expect(component.clientWidth).toEqual(width);
+  expect(component.clientHeight).toEqual(height);
+  expect(component.getBoundingClientRect()).toEqual({ left, top });
   expect(component).toHaveStyle({ background: 'rgb(255, 0, 81) none repeat scroll 0%' });
   component = await findByTestId('hsvgradient-cursor');
   expect(component).toHaveStyle({
-    left: '243px',
-    top: '84px',
+    left: '224px',
+    top: '91px',
   });
   expect(value).toBe(undefined);
   fireEvent(
@@ -270,7 +274,7 @@ test('ColorBox hslgradient cursor changes', async () => {
     }),
   );
   expect(onChange).toHaveBeenCalledTimes(2);
-  expect(value.name).toBe('black');
+  expect(value.name).toBe('white');
   fireEvent(
     component,
     new FakeMouseEvent('mousedown', {
@@ -304,7 +308,7 @@ test('ColorBox hslgradient cursor changes', async () => {
     }),
   );
   expect(onChange).toHaveBeenCalledTimes(4);
-  expect(value.name).toBe('white');
+  expect(value.name).toBe('black');
   fireEvent(
     component,
     new FakeMouseEvent('mousedown', {
@@ -316,8 +320,8 @@ test('ColorBox hslgradient cursor changes', async () => {
     component,
     new FakeMouseEvent('mouseup', {
       bubbles: true,
-      pageX: 500,
-      pageY: 147.5,
+      pageX: left + (width - 1) / 2,
+      pageY: 600,
     }),
   );
   expect(onChange).toHaveBeenCalledTimes(5);
@@ -333,8 +337,8 @@ test('ColorBox hslgradient cursor changes', async () => {
     component,
     new FakeMouseEvent('mouseup', {
       bubbles: true,
-      pageX: 0,
-      pageY: 147.5,
+      pageX: left + (width - 1) / 2,
+      pageY: 0,
     }),
   );
   expect(onChange).toHaveBeenCalledTimes(6);


### PR DESCRIPTION
### Description

This inverts the HSL gradient x/y axes, to have more room for variance on the lightness axis which makes HSL mode more useful in my opinion.

Before:
![image](https://user-images.githubusercontent.com/8385247/119639359-d3b03d80-be17-11eb-8310-cd1a7db835b3.png)

After:
![image](https://user-images.githubusercontent.com/8385247/119639282-c004d700-be17-11eb-9c02-fbcbcd72263a.png)

For comparison, HSV mode:
![image](https://user-images.githubusercontent.com/8385247/119639475-f04c7580-be17-11eb-906e-166fda194480.png)

### Check List

- [x] respect code conventions and usages
- [x] tests and 100% coverage
- [x] well documented
- [x] self review
