### PR TITLE
Fix incorrect typing of the onOpen callback

### DIFF
--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -53,7 +53,7 @@ declare module 'material-ui-color' {
     disableAlpha?: boolean;
     disablePlainColor?: boolean;
     onChange: (color: Color) => void;
-    onOpen?: () => void;
+    onOpen?: (open: boolean) => void;
     openAtStart?: boolean;
     doPopup?: () => void;
     hslGradient?: boolean;


### PR DESCRIPTION
### Fix issues

- [ ] #issuenumber

### Description

Looking at the source code, the optional `onOpen` callback in the `ColorPickerProps` is called with a boolean which indicates whether the dialog is opened or closed.
The boolean was missing from the `index.d.ts` file

### Check List

- [x] respect code conventions and usages
- [x] tests and 100% coverage
- [x] well documented
- [x] self review

### Review targets:
- nodejs / npm / yarn