### PR TITLE
Fix incorrect ColorPickerProps.onChange typing

### DIFF
--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -52,7 +52,7 @@ declare module 'material-ui-color' {
     inputFormats?: ColorFormat[];
     disableAlpha?: boolean;
     disablePlainColor?: boolean;
-    onChange: (color: Color) => void;
+    onChange: (color: ColorValue) => void;
     onOpen?: () => void;
     openAtStart?: boolean;
     doPopup?: () => void;


### PR DESCRIPTION
### Fix issues

- [x] #164

### Description

The ColorPicker's onChange prop's first parameter `color` was wrongly typed as just being `Color`

### Check List

- [x] respect code conventions and usages
- [N/A] tests and 100% coverage
- [N/A] well documented
- [x] self review

### Review targets:
- nodejs / npm / yarn