### PR TITLE
Export ColorObject and ColorError as well

### DIFF
--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -148,6 +148,8 @@ declare module 'material-ui-color' {
     ColorBox,
     ColorBoxProps,
     Color,
+    ColorObject,
+    ColorError,
     ColorFormat,
     ColorType,
     ColorValue,


### PR DESCRIPTION
When implementing an
```
onChange: (color: Color) => void
```
you typically want to know whether the input the user provided is valid or not.

Therefore you need access to the `color.error`, which isn't available according to the TS compiler because it's specific to `ColorError` and not available on `ColorObject`.
As such, writing code like the one below is impossible without casting to `any` first:
```
//change handler
function onChange: (color: Color){
  if(isColorError(color)){
    //do something else, e.g.
    return;
  }
  setColor(color.hex);
}

function isColorError(color: Color): color is ColorError{
  return color.name === "none";
}
```

There are probably other options, e.g. exposing an `isColorError` function from the library. But to cover most use-cases, exposing both those interfaces is probably the easiest.

### Fix issues

- [ ] #issuenumber

### Description

{Please describe here the changes}

### Check List

- [x] respect code conventions and usages
- [x] tests and 100% coverage
- [x] well documented
- [x] self review

### Review targets:
- nodejs / npm / yarn