### PR TITLE
[RM] remove the Legacy package

### DIFF
--- a/examples/colorpicker/src/App.js
+++ b/examples/colorpicker/src/App.js
@@ -1,12 +1,12 @@
 import React, { useState } from "react";
-import { ThemeProvider, createMuiTheme } from "@mui/styles";
+import { createTheme, ThemeProvider } from '@mui/material/styles';
 import CssBaseline from "@mui/material/CssBaseline";
 import Container from "@mui/material/Container";
 import Typography from "@mui/material/Typography";
 import Box from "@mui/material/Box";
 import { ColorPicker, createColor } from "material-ui-color";
 
-const theme = createMuiTheme({
+const theme = createTheme({
   palette: {}
 });
 


### PR DESCRIPTION
Hello,

I'm found out that this library was using the legacy npm package `@mui/styles` which will not work in React 18, I thought to help this community get running!

best regards